### PR TITLE
Feature: Agrega custom validator para la curp

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -1,0 +1,3 @@
+export const Constants = {
+    CURP_REGEX: /^([A-Z][AEIOUX][A-Z]{2}\d{2}(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01])[HM](?:AS|B[CS]|C[CLMSH]|D[FG]|G[TR]|HG|JC|M[CNS]|N[ETL]|OC|PL|Q[TR]|S[PLR]|T[CSL]|VZ|YN|ZS)[B-DF-HJ-NP-TV-Z]{3}[A-Z\d])(\d)$/
+}

--- a/src/components/MigalaRegistro/survey.tsx
+++ b/src/components/MigalaRegistro/survey.tsx
@@ -1,12 +1,23 @@
 import migalaSurvey from 'config/migala-registro-survey.json'
 import * as Survey from "survey-react";
 import { handleOnCompleted } from 'service';
-import { birthDateValidator } from './validators';
+import {birthDateValidator, curpValidator} from './validators';
 
-Survey
-  .FunctionFactory
-  .Instance
-  .register("birthDateValidator", birthDateValidator);
+const registerValidators = (...validators: {name: string, function: any}[]) => {
+
+  validators.forEach( f => {
+    Survey
+        .FunctionFactory
+        .Instance
+        .register(f.name, f.function);
+  })
+}
+
+registerValidators(
+    {name: 'birthDateValidator', function: birthDateValidator},
+    {name: 'curpValidator', function: curpValidator}
+)
+
 
 const MigalaRegistroModel: Survey.ReactSurveyModel = new Survey.Model(migalaSurvey);
 

--- a/src/components/MigalaRegistro/validators.ts
+++ b/src/components/MigalaRegistro/validators.ts
@@ -1,3 +1,4 @@
+import {Constants} from "common/Constants";
 
 export function birthDateValidator(date: any): boolean {
 
@@ -6,10 +7,16 @@ export function birthDateValidator(date: any): boolean {
 
   let age = today.getFullYear() - birthDate.getFullYear();
 
-  var m = today.getMonth() - birthDate.getMonth();
+  let m = today.getMonth() - birthDate.getMonth();
   if (m < 0 || (m === 0 && today.getDate() < birthDate.getDate())) {
     age--;
   }
 
   return age >= 15;
+
+}
+
+export function curpValidator(data: any): boolean {
+  let [ curp ] = data
+  return Constants.CURP_REGEX.test(curp.toString().toUpperCase())
 }

--- a/src/config/migala-registro-survey.json
+++ b/src/config/migala-registro-survey.json
@@ -263,11 +263,11 @@
           "isRequired": true,
           "validators": [
             {
-              "type": "regex",
+              "type": "expression",
               "text": {
                 "es": "Formato de CURP"
               },
-              "regex": "^([A-Z][AEIOUX][A-Z]{2}\\d{2}(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\\d|3[01])[HM](?:AS|B[CS]|C[CLMSH]|D[FG]|G[TR]|HG|JC|M[CNS]|N[ETL]|OC|PL|Q[TR]|S[PLR]|T[CSL]|VZ|YN|ZS)[B-DF-HJ-NP-TV-Z]{3}[A-Z\\d])(\\d)$"
+              "expression": "curpValidator({curp})"
             }
           ]
         },


### PR DESCRIPTION
### Problema
- #9 

### Solución

Se extrajo la validación a un customValidator el cual abstrae un test con regex y permite ser mas escalable, así mismo se agrega un función para generar los custom validators sin repetir tanto código

### Como probar 
- Descargar el proyecto
- Ejecutar yarn install
- Ejecutar yarn start
- Iniciar el formulario con datos dummy
- Cuando se llegue a la sección CURP ingresar una curp erronea
- Finalizar los campos de esa misma pantalla y dar en next deberia mostrar el error de CURP no valida
- Ingresar una CURP valida y dar next
- Deberia permitire seguir en el flujo