### PR TITLE
Arreglando validación para clave electoral

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -1,3 +1,4 @@
 export const Constants = {
-    CURP_REGEX: /^([A-Z][AEIOUX][A-Z]{2}\d{2}(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01])[HM](?:AS|B[CS]|C[CLMSH]|D[FG]|G[TR]|HG|JC|M[CNS]|N[ETL]|OC|PL|Q[TR]|S[PLR]|T[CSL]|VZ|YN|ZS)[B-DF-HJ-NP-TV-Z]{3}[A-Z\d])(\d)$/
+    CURP_REGEX: /^([A-Z][AEIOUX][A-Z]{2}\d{2}(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01])[HM](?:AS|B[CS]|C[CLMSH]|D[FG]|G[TR]|HG|JC|M[CNS]|N[ETL]|OC|PL|Q[TR]|S[PLR]|T[CSL]|VZ|YN|ZS)[B-DF-HJ-NP-TV-Z]{3}[A-Z\d])(\d)$/,
+    CLAVE_ELECTOR_REGEX: /^([A-Z]{6}[0-9]{7,8}[HM][0-9]{3})$/
 }

--- a/src/components/MigalaRegistro/survey.tsx
+++ b/src/components/MigalaRegistro/survey.tsx
@@ -2,7 +2,11 @@ import migalaSurvey from 'config/migala-registro-survey.json'
 import * as Survey from "survey-react";
 import { handleOnCompleted } from 'service';
 import showdown from 'showdown';
-import {birthDateValidator, curpValidator} from './validators';
+import {
+  birthDateValidator,
+  curpValidator,
+  claveElectorValidator
+} from './validators';
 
 const registerValidators = (...validators: {name: string, function: any}[]) => {
 
@@ -16,7 +20,8 @@ const registerValidators = (...validators: {name: string, function: any}[]) => {
 
 registerValidators(
     {name: 'birthDateValidator', function: birthDateValidator},
-    {name: 'curpValidator', function: curpValidator}
+    {name: 'curpValidator', function: curpValidator},
+    {name: 'claveElectorValidator', function: claveElectorValidator},
 )
 
 const MigalaRegistroModel: Survey.ReactSurveyModel = new Survey.Model(migalaSurvey);

--- a/src/components/MigalaRegistro/validators.ts
+++ b/src/components/MigalaRegistro/validators.ts
@@ -1,3 +1,5 @@
+
+
 import {Constants} from "common/Constants";
 
 export function birthDateValidator(date: any): boolean {
@@ -16,7 +18,12 @@ export function birthDateValidator(date: any): boolean {
 
 }
 
-export function curpValidator(data: any): boolean {
+export function curpValidator(data: string[]): boolean {
   let [ curp ] = data
   return Constants.CURP_REGEX.test(curp.toString().toUpperCase())
+}
+
+export function claveElectorValidator(data: string[]): boolean{
+  let [clave_elector] = data; 
+  return Constants.CLAVE_ELECTOR_REGEX.test(clave_elector.toUpperCase());
 }

--- a/src/config/migala-registro-survey.json
+++ b/src/config/migala-registro-survey.json
@@ -368,11 +368,11 @@
               },
               "validators": [
                 {
-                  "type": "regex",
+                  "type": "expression",
                   "text": {
-                    "es": "Formato de Clave de Elector"
+                    "es": "Error en formato"
                   },
-                  "regex": "^([A-Z]{6}[0-9]{7,8}[HM][0-9]{3})$"
+                  "expression": "claveElectorValidator({clave_elector})"
                 }
               ]
             }


### PR DESCRIPTION
La clave electoral presentaba el mismo error que la CURP. Una vez que ingresabas un valor no válido, el formulario no te dejaba continuar.